### PR TITLE
Upgrade to gha-shared-workflows@v7 with publish improvements

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -32,7 +32,7 @@ jobs:
     name: "Release"
     if: github.ref_type == 'tag'
     uses: pronovic/gha-shared-workflows/.github/workflows/poetry-release.yml@v7
-    needs: [ linux-build-and-test, macos-build-and-test, windows-build-and-test ]
+    needs: [ linux-build-and-test, macos-build-and-test ]
     secrets: inherit
     with:
       publish-pypi: false

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -15,26 +15,24 @@ concurrency:
 jobs:
   linux-build-and-test:
     name: "Linux"
-    uses: pronovic/gha-shared-workflows/.github/workflows/poetry-build-and-test.yml@v6
+    uses: pronovic/gha-shared-workflows/.github/workflows/poetry-build-and-test.yml@v7
     secrets: inherit
     with:
       matrix-os-version: "[ 'ubuntu-latest' ]"
-      matrix-python-version: "[ '3.11', '3.12', '3.13' ]"
-      enable-coveralls: false 
+      matrix-python-version: "[ '3.11', '3.12', '3.13' ]"  # run Linux tests on all supported Python versions
+      persist-python-version: "3.11"  # persist artifacts for the oldest supported Python version
   macos-build-and-test:
     name: "MacOS"
-    uses: pronovic/gha-shared-workflows/.github/workflows/poetry-build-and-test.yml@v6
+    uses: pronovic/gha-shared-workflows/.github/workflows/poetry-build-and-test.yml@v7
     secrets: inherit
     with:
       matrix-os-version: "[ 'macos-latest' ]"
       matrix-python-version: "[ '3.13' ]"  # only run MacOS tests on latest Python
-      enable-coveralls: false 
   release:
     name: "Release"
     if: github.ref_type == 'tag'
-    uses: pronovic/gha-shared-workflows/.github/workflows/poetry-release.yml@v6
-    needs: [ linux-build-and-test ]
+    uses: pronovic/gha-shared-workflows/.github/workflows/poetry-release.yml@v7
+    needs: [ linux-build-and-test, macos-build-and-test, windows-build-and-test ]
     secrets: inherit
     with:
-      python-version: "3.11"   # run release with oldest supported Python version
       publish-pypi: false

--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,7 @@
+Version 0.3.3     unreleased
+
+	* Upgrade to gha-shared-workflows@v7 with publish improvements.
+
 Version 0.3.2     12 Dec 2024
 
 	* Allow "--env -" to use the environment directly.


### PR DESCRIPTION
This work was prototyped in a [series of commits in the apologies repo](https://github.com/pronovic/apologies/compare/v0.1.50..v0.1.54).