### PR TITLE
Remove restriction on branches for PR build

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -7,8 +7,6 @@ on:
     tags:
       - "v*"
   pull_request:
-    branches:
-      - main
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/Changelog
+++ b/Changelog
@@ -1,5 +1,6 @@
 Version 0.3.8     unreleased
 
+	* Adjust GHA build process to allow builds for stacked PRs.
 	* Update the urllib3 transitive dependency to address CVE-2025-50181.
 	* Update the fastapi and starlette dependencies to address CVE-2025-54121.
 


### PR DESCRIPTION
I want to be able to stack pull requests, and the current GitHub Actions workflow prevents builds from happening on stacked PRs.  Prototyped in [apologies PR #70](https://github.com/pronovic/apologies/pull/70).