### PR TITLE
Update the MyPy configuration so we're using latest rules

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,6 +1,7 @@
 Version 0.3.8     unreleased
 
 	* Adjust GHA build process to allow builds for stacked PRs.
+	* Update the MyPy configuration so we're using latest rules.
 	* Add a new `run clean` target to clean up generated data.
 	* Update the urllib3 transitive dependency to address CVE-2025-50181.
 	* Update the fastapi and starlette dependencies to address CVE-2025-54121.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,12 +103,12 @@ filterwarnings = [
 ]
 
 [tool.mypy]
-# Settings are mostly equivalent to strict=true as of v1.14.1
+files = [ "src" ]
 pretty = true
 show_absolute_path = true
 show_column_numbers = true
 show_error_codes = true
-files = [ "src/auth0token" ]
+# Settings equivalent to strict=true as of v1.17.1
 check_untyped_defs = true
 disallow_any_generics = true
 disallow_incomplete_defs = true
@@ -116,12 +116,15 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = false
 disallow_untyped_defs = true
-no_implicit_optional = true
+extra_checks = true
 no_implicit_reexport = true
 strict_equality = true
-strict_optional = true
 warn_redundant_casts = true
 warn_return_any = true
-warn_no_return = true
 warn_unused_configs = true
 warn_unused_ignores = true
+# Additional settings above and beyond strict=true
+implicit_optional = false
+strict_optional = true
+warn_no_return = true
+warn_unreachable = true


### PR DESCRIPTION
This updates the MyPy configuration, adding a few new flags and making adjustments so it's clear which flags are related to `--strict` and which are other flags that I've added above and beyond that. Prototyped in [apologies PR #67](https://github.com/pronovic/apologies/pull/67).